### PR TITLE
feat: neynar signature verification + error management inside nominationsHandler

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -26,7 +26,6 @@ const envSchema = z.object({
     .optional(),
   REDIS_USERNAME: z.string().optional(),
   REDIS_PASSWORD: z.string().optional(),
-  // WARPCAST_API_KEY: z.string(),
   WEBHOOK_KEY: z.string().trim().min(1),
   REMINDER_CRON: z.string().trim().optional().default("0 0 * * 3"),
   WEEKLY_STATS_CRON: z.string().trim().optional().default("0 0 * * 0"),
@@ -39,6 +38,7 @@ const envSchema = z.object({
     .string()
     .transform((val) => (val ? parseInt(val) : undefined)),
   BUILDBOT_XMTP_PRIVATE_KEY: z.string().trim().min(1),
+  BUILD_SHARED_SECRET: z.string().trim().min(1),
   // TALENTBOT
   TALENTBOT_WARPCAST_API_KEY: z.string(),
   TALENTBOT_XMTP_PRIVATE_KEY: z.string().trim().min(1),

--- a/src/middlewares.ts
+++ b/src/middlewares.ts
@@ -1,5 +1,9 @@
 import { NextFunction, Request, Response } from "express";
 import { env } from "./env.js";
+import { createHmac } from "crypto";
+import { Logger } from "./utils/logger.js";
+
+const logger = new Logger("middleware");
 
 /**
  * @dev simple middleware that checks for the presence of the x-webhook-key header
@@ -17,5 +21,41 @@ export const webhookKeyMiddleware = (
     res.status(401).send("Unauthorized");
     return;
   }
+  next();
+};
+
+/**
+ * @dev middleware that checks for the presence of the X-Neynar-Signature header and validates it (if there are multiple webhooks calling the bot we can use this to verify the source and prevent malicious or multiple requests)
+ * @param {Request} req input express request
+ * @param {Response} res output express response
+ * @param {NextFunction} next express next function
+ */
+export const neynarSignatureMiddleware = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  const signature = req.header("X-Neynar-Signature");
+  if (!signature) {
+    logger.error("Neynar Signature missing from request headers");
+    res
+      .status(401)
+      .send("Unauthorized - Neynar Signature missing from request headers");
+    return;
+  }
+
+  const webhookSecret = env.BUILD_SHARED_SECRET;
+  const body = JSON.stringify(req.body);
+  const generatedSignature = createHmac("sha512", webhookSecret)
+    .update(body)
+    .digest("hex");
+
+  if (signature !== generatedSignature) {
+    logger.error("Invalid Neynar Signature");
+    res.status(401).send("Unauthorized - invalid Neynar Signature");
+    return;
+  }
+
+  logger.log("Neynar Signature is valid");
   next();
 };

--- a/src/queues/casts.ts
+++ b/src/queues/casts.ts
@@ -14,7 +14,9 @@ export const processCast = async (job: { data: SimpleCastBody }) => {
   // @ts-ignore
   const { text }: SimpleCastBody = job.data;
 
-  console.log(`[casts worker] [${Date.now()}] - new cast received. iterating.`);
+  console.log(
+    `[casts worker] [${Date.now()}] - new cast received. iterating. text: ${text}`
+  );
 
   /*const hash = await publishCast(text, {
     replyTo: env.FARCASTER_REPLY_TO_CAST_HASH,

--- a/src/routes/webhooks/index.ts
+++ b/src/routes/webhooks/index.ts
@@ -2,7 +2,10 @@ import express from "express";
 import { mentionsHandler } from "./mentions.js";
 import { nominationsHandler } from "./nominations.js";
 import { mentionsSchema } from "../../schemas.js";
-import { webhookKeyMiddleware } from "../../middlewares.js";
+import {
+  neynarSignatureMiddleware,
+  webhookKeyMiddleware,
+} from "../../middlewares.js";
 import { validateBodySchema } from "../../validators.js";
 
 const webhooksRouter = express.Router();
@@ -14,6 +17,10 @@ webhooksRouter.post(
   mentionsHandler
 );
 
-webhooksRouter.post("/nominations", nominationsHandler);
+webhooksRouter.post(
+  "/nominations",
+  neynarSignatureMiddleware,
+  nominationsHandler
+);
 
 export { webhooksRouter };

--- a/src/utils/farcaster.ts
+++ b/src/utils/farcaster.ts
@@ -16,20 +16,19 @@ const client = new NeynarAPIClient(env.FARCASTER_API_KEY as string);
 const webhookName = env.BUILDBOT_WEBHOOK_NAME;
 const webhookUrl =
   env.BUILDBOT_WEBHOOK_TARGET_BASE_URL + "/webhooks/nominations";
-const buildbotFid = env.BUILDBOT_FARCASTER_FID as number;
+// const buildbotFid = env.BUILDBOT_FARCASTER_FID as number;
 
 const logger = new Logger("farcaster");
 
 export const setupWebhook = async () => {
   const createdWebhooks = await client.fetchWebhooks();
-  // check if a webhook with the same name already exists
   const webhook = createdWebhooks.webhooks.find(
     (webhook) =>
       webhook.title === webhookName && webhook.target_url === webhookUrl
   );
   if (webhook) {
     logger.log(
-      `webhook already exists, using webhook with id: ${webhook.webhook_id}`
+      `webhook already exists, using webhook with id ${webhook.webhook_id} and title ${webhook.title}`
     );
     return {
       success: true,
@@ -37,15 +36,18 @@ export const setupWebhook = async () => {
       webhook,
     };
   }
+  throw new Error(
+    "webhook does not exist - please create a new webhook before continuing."
+  );
 
-  logger.log("webhook does not exist - creating new webhook");
-  return await client.publishWebhook(webhookName, webhookUrl, {
-    subscription: {
-      "cast.created": {
-        mentioned_fids: [buildbotFid],
-      },
-    },
-  });
+  // logger.log("webhook does not exist - creating new webhook");
+  // return await client.publishWebhook(webhookName, webhookUrl, {
+  //   subscription: {
+  //     "cast.created": {
+  //       mentioned_fids: [buildbotFid],
+  //     },
+  //   },
+  // });
 };
 
 /**


### PR DESCRIPTION
what I've done in this PR:
- integrated neynar signature verification (described here: https://docs.neynar.com/docs/how-to-verify-the-incoming-webhooks-using-signatures)
- fix nominationsHandler:
  - now the bot replies only to casts with the specified pattern (@buildbot nom(inate) [@username])
  - and replies with returned error messages when the buildbot api returns a 400 error